### PR TITLE
Various updates

### DIFF
--- a/api/v1beta1/dnsrecord_types.go
+++ b/api/v1beta1/dnsrecord_types.go
@@ -28,24 +28,25 @@ type DNSRecordSpecIPRef struct {
 
 // DNSRecordSpec defines the desired state of DNSRecord
 type DNSRecordSpec struct {
-	// Name of the DNS record (e.g. app.example.com)
+	// DNS record name (e.g. example.com)
+	// +kubebuilder:validation:MaxLength=255
 	Name string `json:"name"`
-	// Content of the DNS record (e.g. 144.231.20.1)
+	// DNS record content (e.g. 127.0.0.1)
 	// +optional
 	Content string `json:"content,omitempty"`
 	// Reference to an IP object
 	// +optional
 	IPRef DNSRecordSpecIPRef `json:"ipRef,omitempty"`
-	// Type of DNS record (A, AAAA, CNAME)
+	// DNS record type (A, AAAA, CNAME)
 	// +kubebuilder:validation:Enum=A;AAAA;CNAME
 	// +kubebuilder:default=A
 	// +optional
 	Type string `json:"type,omitempty"`
-	// Proxied indicates whether the DNS record should be proxied
+	// Whether the record is receiving the performance and security benefits of Cloudflare
 	// +kubebuilder:default=true
 	// +optional
 	Proxied *bool `json:"proxied,omitempty"`
-	// TTL of the DNS record (e.g. 300, 1 for automatic)
+	// Time to live, in seconds, of the DNS record. Must be between 60 and 86400, or 1 for 'automatic' (e.g. 3600)
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=86400
 	// +kubebuilder:default=1

--- a/config/crd/bases/cf.containeroo.ch_dnsrecords.yaml
+++ b/config/crd/bases/cf.containeroo.ch_dnsrecords.yaml
@@ -55,7 +55,7 @@ spec:
             description: DNSRecordSpec defines the desired state of DNSRecord
             properties:
               content:
-                description: Content of the DNS record (e.g. 144.231.20.1)
+                description: DNS record content (e.g. 127.0.0.1)
                 type: string
               interval:
                 default: 5m
@@ -69,21 +69,24 @@ spec:
                     type: string
                 type: object
               name:
-                description: Name of the DNS record (e.g. app.example.com)
+                description: DNS record name (e.g. example.com)
+                maxLength: 255
                 type: string
               proxied:
                 default: true
-                description: Proxied indicates whether the DNS record should be proxied
+                description: Whether the record is receiving the performance and security
+                  benefits of Cloudflare
                 type: boolean
               ttl:
                 default: 1
-                description: TTL of the DNS record (e.g. 300, 1 for automatic)
+                description: Time to live, in seconds, of the DNS record. Must be
+                  between 60 and 86400, or 1 for 'automatic' (e.g. 3600)
                 maximum: 86400
                 minimum: 1
                 type: integer
               type:
                 default: A
-                description: Type of DNS record (A, AAAA, CNAME)
+                description: DNS record type (A, AAAA, CNAME)
                 enum:
                 - A
                 - AAAA

--- a/controllers/ip_controller.go
+++ b/controllers/ip_controller.go
@@ -24,7 +24,6 @@ import (
 	cfv1beta1 "github.com/containeroo/cloudflare-operator/api/v1beta1"
 	"github.com/go-logr/logr"
 	"io"
-	"io/ioutil"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -265,7 +264,7 @@ func (r *IPReconciler) getIPSource(ctx context.Context, source cfv1beta1.IPSpecI
 	if resp.StatusCode != 200 {
 		return "", fmt.Errorf("failed to get IP from %s: %s", source.URL, resp.Status)
 	}
-	response, err := ioutil.ReadAll(resp.Body)
+	response, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("failed to get IP from %s: %s", source.URL, err)
 	}


### PR DESCRIPTION
This PR does the following:

- Sync DNSRecord descriptions with Cloudflares API
- Ensure DNS record names can only be 255 characters long
- Migrate away from deprecated `ioutil`