### PR TITLE
fix(zone_controller): fix acme-challenge filter

### DIFF
--- a/controllers/zone_controller.go
+++ b/controllers/zone_controller.go
@@ -127,7 +127,7 @@ func (r *ZoneReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	}
 
 	for _, cfDnsRecord := range cfDnsRecords {
-		if cfDnsRecord.Type == "TXT" && strings.HasPrefix(cfDnsRecord.Content, "_acme-challenge") {
+		if cfDnsRecord.Type == "TXT" && strings.HasPrefix(cfDnsRecord.Name, "_acme-challenge") {
 			continue
 		}
 


### PR DESCRIPTION
Closes #282 

This PR fixes the filtering for acme-challenge related TXT records.

## Checklist

- [X] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [X] PR contains a single logical change (to build a better changelog).
- [X] Update the documentation.
- [X] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
