### PR TITLE
Remove deprecated 'created-by' label from Zones and Ingress DNSRecords

### DIFF
--- a/controllers/account_controller.go
+++ b/controllers/account_controller.go
@@ -164,7 +164,6 @@ func (r *AccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 					Name: strings.ReplaceAll(operatorManagedZone.Name, ".", "-"),
 					Labels: map[string]string{
 						"app.kubernetes.io/managed-by": "cloudflare-operator",
-						"app.kubernetes.io/created-by": "cloudflare-operator",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{

--- a/controllers/ingress_controller.go
+++ b/controllers/ingress_controller.go
@@ -161,7 +161,6 @@ func (r *IngressReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				Namespace: instance.Namespace,
 				Labels: map[string]string{
 					"app.kubernetes.io/managed-by": "cloudflare-operator",
-					"app.kubernetes.io/created-by": "cloudflare-operator",
 				},
 				OwnerReferences: []metav1.OwnerReference{
 					{


### PR DESCRIPTION
Ref: https://kubernetes.io/docs/reference/labels-annotations-taints/#app-kubernetes-io-created-by-deprecated

When cloudflare-operator creates a Zone or a DNSRecord object from an Ingress, it currently sets the `app.kubernetes.io/created-by` label. This has been deprecated for a long time and we should remove it.

## Checklist

- [X] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [X] PR contains a single logical change (to build a better changelog).
- [X] Update the documentation.
- [X] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [X] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
