### PR TITLE
Added missing Ingress Finaliser Permission to Role

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -124,3 +124,9 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/finalizers
+  verbs:
+  - update

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -124,9 +124,3 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - ingresses/finalizers
-  verbs:
-  - update

--- a/internal/controller/ingress_controller.go
+++ b/internal/controller/ingress_controller.go
@@ -42,6 +42,7 @@ type IngressReconciler struct {
 }
 
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
Fixing issue where on OpenShift the Operator doesn't have the permission to update Finaliser on Ingress Objects.

Error message was as follows: `XXX is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on.`

Found the solution which is similar to this issue: https://github.com/FairwindsOps/rbac-manager/issues/180

## Checklist

- [X] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [X] PR contains a single logical change (to build a better changelog).
- [X] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [X] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
