### PR TITLE
fix(ingress): delete orphaned dns records

### DIFF
--- a/internal/controller/ingress_controller.go
+++ b/internal/controller/ingress_controller.go
@@ -79,6 +79,16 @@ func (r *IngressReconciler) reconcileIngress(ctx context.Context, ingress *netwo
 
 	annotations := ingress.GetAnnotations()
 
+	if annotations["cloudflare-operator.io/content"] == "" && annotations["cloudflare-operator.io/ip-ref"] == "" {
+		for _, record := range dnsRecords.Items {
+			if err := r.Delete(ctx, &record); err != nil {
+				log.Error(err, "Failed to delete DNSRecord", "name", record.Name)
+			}
+		}
+
+		return ctrl.Result{}, nil
+	}
+
 	dnsRecordSpec := r.parseAnnotations(annotations)
 	existingRecords := make(map[string]cloudflareoperatoriov1.DNSRecord)
 	for _, record := range dnsRecords.Items {

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -148,3 +148,22 @@ func VerifyDNSRecordContent(objName, expectedContent string) error {
 	}
 	return nil
 }
+
+func VerifyDNSRecordAbsent(objName string) error {
+	cmd := exec.Command(
+		"kubectl",
+		"get",
+		"dnsrecord",
+		objName,
+		"-n",
+		"cloudflare-operator-system",
+	)
+	status, err := Run(cmd)
+	if err != nil {
+		if strings.Contains(string(status), "NotFound") {
+			return nil
+		}
+		return err
+	}
+	return fmt.Errorf("dnsrecord %s still exists", objName)
+}


### PR DESCRIPTION
This pull request fixes an issue that lead to orphaned dns records when an Ingress which previously had DNS records got their annotations removed.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
