### PR TITLE
Auto-match Zones to Accounts via spec.managedZones (multi-account support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ cloudflare-operator helps to:
 - Keep Cloudflare DNS records up to date
 - Update your external IP address on Cloudflare DNS records
 
+> **Heads-up:** every `Account` custom resource must list the zones it is allowed to manage in `spec.managedZones`. Zones and DNS records are matched to accounts automatically using this list.
+
 ## What can I do with cloudflare-operator?
 
 cloudflare-operator is based on a set of Kubernetes API extensions ("custom resources"), which control Cloudflare DNS records.

--- a/api/v1/account_types.go
+++ b/api/v1/account_types.go
@@ -35,9 +35,8 @@ type AccountSpec struct {
 	// +optional
 	Interval metav1.Duration `json:"interval,omitempty"`
 	// List of zone names that should be managed by cloudflare-operator
-	// Deprecated and will be removed in a future release
+	// Used to automatically match zones with the correct account
 	// +optional
-	// +deprecated
 	ManagedZones []string `json:"managedZones,omitempty"`
 }
 

--- a/config/crd/bases/cloudflare-operator.io_accounts.yaml
+++ b/config/crd/bases/cloudflare-operator.io_accounts.yaml
@@ -70,7 +70,7 @@ spec:
               managedZones:
                 description: |-
                   List of zone names that should be managed by cloudflare-operator
-                  Deprecated and will be removed in a future release
+                  Used to automatically match zones with the correct account
                 items:
                   type: string
                 type: array

--- a/config/samples/cloudflareoperatorio_v1_account.yaml
+++ b/config/samples/cloudflareoperatorio_v1_account.yaml
@@ -17,3 +17,5 @@ spec:
     secretRef:
       name: api-token-sample
       namespace: cloudflare-operator-system
+  managedZones:
+    - containeroo-test.org

--- a/internal/controller/account_manager.go
+++ b/internal/controller/account_manager.go
@@ -1,0 +1,173 @@
+package controller
+
+import (
+	"errors"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/cloudflare/cloudflare-go"
+)
+
+var (
+	errNoAccountForZone = errors.New("no account manages the requested zone")
+	errMultipleAccounts = errors.New("multiple accounts manage the requested zone")
+)
+
+// accountInfo holds the data we need to interact with Cloudflare for a single account.
+type accountInfo struct {
+	api          *cloudflare.API
+	managedZones map[string]struct{}
+	token        string
+}
+
+// AccountManager keeps track of available Cloudflare accounts and the zones they manage.
+type AccountManager struct {
+	mu             sync.RWMutex
+	accounts       map[string]*accountInfo
+	zoneToAccounts map[string]map[string]struct{}
+}
+
+// NewAccountManager returns an initialized AccountManager instance.
+func NewAccountManager() *AccountManager {
+	return &AccountManager{
+		accounts:       make(map[string]*accountInfo),
+		zoneToAccounts: make(map[string]map[string]struct{}),
+	}
+}
+
+// UpsertAccount registers or updates an account and its managed zones.
+func (m *AccountManager) UpsertAccount(name string, api *cloudflare.API, token string, managedZones []string) {
+	canonicalZones := normalizeZones(managedZones)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// remove old zone membership for this account
+	if existing, ok := m.accounts[name]; ok {
+		for zone := range existing.managedZones {
+			m.removeZoneMembership(zone, name)
+		}
+	}
+
+	zoneSet := make(map[string]struct{}, len(canonicalZones))
+	for _, zone := range canonicalZones {
+		zoneSet[zone] = struct{}{}
+		if _, ok := m.zoneToAccounts[zone]; !ok {
+			m.zoneToAccounts[zone] = make(map[string]struct{})
+		}
+		m.zoneToAccounts[zone][name] = struct{}{}
+	}
+
+	m.accounts[name] = &accountInfo{
+		api:          api,
+		managedZones: zoneSet,
+		token:        token,
+	}
+}
+
+// RemoveAccount unregisters an account and clears any zone mappings.
+func (m *AccountManager) RemoveAccount(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entry, ok := m.accounts[name]
+	if !ok {
+		return
+	}
+
+	for zone := range entry.managedZones {
+		m.removeZoneMembership(zone, name)
+	}
+
+	delete(m.accounts, name)
+}
+
+// GetAccount returns the stored account info by name.
+func (m *AccountManager) GetAccount(name string) (*cloudflare.API, string, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	entry, ok := m.accounts[name]
+	if !ok {
+		return nil, "", false
+	}
+
+	return entry.api, entry.token, true
+}
+
+// AccountForZone returns the Cloudflare client for the account managing the provided zone.
+// If no account manages the zone, errNoAccountForZone is returned.
+// If multiple accounts manage the same zone, errMultipleAccounts is returned along with the list of candidates.
+func (m *AccountManager) AccountForZone(zone string) (*cloudflare.API, string, error) {
+	canonical := canonicalZone(zone)
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	accounts, ok := m.zoneToAccounts[canonical]
+	if !ok || len(accounts) == 0 {
+		return nil, "", errNoAccountForZone
+	}
+
+	if len(accounts) > 1 {
+		names := make([]string, 0, len(accounts))
+		for name := range accounts {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		return nil, strings.Join(names, ", "), errMultipleAccounts
+	}
+
+	var accountName string
+	for name := range accounts {
+		accountName = name
+	}
+
+	entry, ok := m.accounts[accountName]
+	if !ok {
+		return nil, accountName, errNoAccountForZone
+	}
+
+	return entry.api, accountName, nil
+}
+
+func (m *AccountManager) removeZoneMembership(zone, accountName string) {
+	canonical := canonicalZone(zone)
+	members, ok := m.zoneToAccounts[canonical]
+	if !ok {
+		return
+	}
+
+	delete(members, accountName)
+	if len(members) == 0 {
+		delete(m.zoneToAccounts, canonical)
+	}
+}
+
+func normalizeZones(zones []string) []string {
+	result := make([]string, 0, len(zones))
+	seen := make(map[string]struct{}, len(zones))
+	for _, zone := range zones {
+		canonical := canonicalZone(zone)
+		if canonical == "" {
+			continue
+		}
+		if _, ok := seen[canonical]; ok {
+			continue
+		}
+		seen[canonical] = struct{}{}
+		result = append(result, canonical)
+	}
+
+	sort.Strings(result)
+	return result
+}
+
+func canonicalZone(zone string) string {
+	zone = strings.TrimSpace(zone)
+	if zone == "" {
+		return ""
+	}
+	return strings.ToLower(zone)
+}


### PR DESCRIPTION
Summary
- Introduces automatic matching of Zones and DNSRecords to Accounts using `Account.spec.managedZones`.
- Replaces the single shared Cloudflare client with per-account clients managed in-memory.
- Makes ownership deterministic in multi-account setups.

Changes
- Added `AccountManager` to map accounts and zones, resolve conflicts, and provide per-account Cloudflare clients.
- `AccountReconciler` creates a client from Secret and registers the account + managed zones; cleans up on delete.
- `ZoneReconciler`/`DNSRecordReconciler` resolve the account by zone name and use the corresponding client; emit clear errors for no/multiple matches.
- Updated samples: `account-sample` now includes `spec.managedZones`.
- Updated README with a heads-up about `managedZones` requirement.
- Adjusted unit/e2e tests to the new flow.

Breaking
- Every `Account` must list all managed apex zones in `spec.managedZones`. Zones/DNSRecords without a matching account will not reconcile.

Migration
- For each `Account`, add all apex zones to `spec.managedZones`.
- Reapply CRDs/manifests; Secrets with `apiToken` are unchanged.

Testing
- Unit tests updated for manager-based resolution.
- E2E uses updated sample with `managedZones`; ensure `CF_API_TOKEN` and `CF_ZONE_ID` are set.

Docs
- README and samples updated. Consider a follow-up docs page “How matching works”.

Checklist
- [x] Meaningful title and description for changelog
- [x] Single logical change
- [x] Documentation updated (README + samples)
- [x] Labels: enhancement, breaking, documentation
- [x] Linked related issues/PRs