### PR TITLE
[codex] Add Gateway API TLSRoute support

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -31,6 +31,12 @@ resources:
   kind: HTTPRoute
   path: sigs.k8s.io/gateway-api/apis/v1
   version: v1
+- controller: true
+  domain: networking.k8s.io
+  group: gateway
+  kind: TLSRoute
+  path: sigs.k8s.io/gateway-api/apis/v1
+  version: v1
 - api:
     crdVersion: v1
   controller: true

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"crypto/tls"
+	"errors"
 	"flag"
 	"os"
 	"time"
@@ -26,6 +27,7 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -85,7 +87,7 @@ func main() {
 	flag.DurationVar(&defaultReconcileInterval, "default-reconcile-interval", 5*time.Minute,
 		"The default interval at which to reconcile resources")
 	flag.BoolVar(&enableGatewayAPI, "enable-gateway-api", false,
-		"Enable reconciliation for Gateway API HTTPRoute resources")
+		"Enable reconciliation for Gateway API HTTPRoute and TLSRoute resources")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -168,22 +170,47 @@ func main() {
 		os.Exit(1)
 	}
 	if enableGatewayAPI {
-		_, restMappingErr := mgr.GetRESTMapper().RESTMapping(
-			schema.GroupKind{Group: gatewayv1.GroupVersion.Group, Kind: "HTTPRoute"},
-			gatewayv1.GroupVersion.Version,
-		)
-		if restMappingErr != nil {
-			setupLog.Error(restMappingErr, "gateway API CRD not found; install Gateway API or disable --enable-gateway-api")
+		availableGatewayAPIKinds := make(map[string]struct{})
+		for _, kind := range []string{"HTTPRoute", "TLSRoute"} {
+			_, restMappingErr := mgr.GetRESTMapper().RESTMapping(
+				schema.GroupKind{Group: gatewayv1.GroupVersion.Group, Kind: kind},
+				gatewayv1.GroupVersion.Version,
+			)
+			if restMappingErr != nil {
+				if meta.IsNoMatchError(restMappingErr) {
+					setupLog.Info("gateway API CRD not found; skipping controller", "kind", kind)
+					continue
+				}
+				setupLog.Error(restMappingErr, "unable to discover gateway API CRD", "kind", kind)
+				os.Exit(1)
+			}
+			availableGatewayAPIKinds[kind] = struct{}{}
+		}
+		if len(availableGatewayAPIKinds) == 0 {
+			setupLog.Error(errors.New("no Gateway API route CRDs found"), "install Gateway API or disable --enable-gateway-api")
 			os.Exit(1)
 		}
-		if err = (&controller.HTTPRouteReconciler{
-			Client:                   mgr.GetClient(),
-			Scheme:                   mgr.GetScheme(),
-			RetryInterval:            retryInterval,
-			DefaultReconcileInterval: defaultReconcileInterval,
-		}).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create controller", "controller", "HTTPRoute")
-			os.Exit(1)
+		if _, ok := availableGatewayAPIKinds["HTTPRoute"]; ok {
+			if err = (&controller.HTTPRouteReconciler{
+				Client:                   mgr.GetClient(),
+				Scheme:                   mgr.GetScheme(),
+				RetryInterval:            retryInterval,
+				DefaultReconcileInterval: defaultReconcileInterval,
+			}).SetupWithManager(mgr); err != nil {
+				setupLog.Error(err, "unable to create controller", "controller", "HTTPRoute")
+				os.Exit(1)
+			}
+		}
+		if _, ok := availableGatewayAPIKinds["TLSRoute"]; ok {
+			if err = (&controller.TLSRouteReconciler{
+				Client:                   mgr.GetClient(),
+				Scheme:                   mgr.GetScheme(),
+				RetryInterval:            retryInterval,
+				DefaultReconcileInterval: defaultReconcileInterval,
+			}).SetupWithManager(mgr); err != nil {
+				setupLog.Error(err, "unable to create controller", "controller", "TLSRoute")
+				os.Exit(1)
+			}
 		}
 	}
 	if err = (&controller.DNSRecordReconciler{

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -51,6 +51,7 @@ rules:
   - gateway.networking.k8s.io
   resources:
   - httproutes
+  - tlsroutes
   verbs:
   - get
   - list
@@ -59,6 +60,7 @@ rules:
   - gateway.networking.k8s.io
   resources:
   - httproutes/finalizers
+  - tlsroutes/finalizers
   verbs:
   - update
 - apiGroups:

--- a/config/samples/gateway_v1_tlsroute.yaml
+++ b/config/samples/gateway_v1_tlsroute.yaml
@@ -1,0 +1,17 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: TLSRoute
+metadata:
+  name: sample-tlsroute
+  namespace: cloudflare-operator-system
+  annotations:
+    cloudflare-operator.io/content: 1.1.1.1
+    cloudflare-operator.io/proxied: "false"
+spec:
+  hostnames:
+    - tls.containeroo-test.org
+  parentRefs:
+    - name: sample-gateway
+  rules:
+    - backendRefs:
+        - name: sample-service
+          port: 443

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
 - cloudflareoperatorio_v1_zone.yaml
 - networking_v1_ingress.yaml
 - gateway_v1_httproute.yaml
+- gateway_v1_tlsroute.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples

--- a/internal/controller/dns_host_reconciler.go
+++ b/internal/controller/dns_host_reconciler.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-// DNSHostReconciler reconciles DNSRecords for a host-based resource (Ingress, HTTPRoute, ...)
+// DNSHostReconciler reconciles DNSRecords for a host-based resource (Ingress, HTTPRoute, TLSRoute, ...)
 type DNSHostReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme

--- a/internal/controller/dnsrecord_controller.go
+++ b/internal/controller/dnsrecord_controller.go
@@ -81,7 +81,7 @@ func (r *DNSRecordReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 			ownerReferences := obj.GetOwnerReferences()
 			var ownerReferencesUID string
 			for _, ownerReference := range ownerReferences {
-				if ownerReference.Kind != "Ingress" && ownerReference.Kind != "HTTPRoute" {
+				if ownerReference.Kind != "Ingress" && ownerReference.Kind != "HTTPRoute" && ownerReference.Kind != "TLSRoute" {
 					continue
 				}
 				ownerReferencesUID = string(ownerReference.UID)

--- a/internal/controller/tlsroute_controller.go
+++ b/internal/controller/tlsroute_controller.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2025 containeroo
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"time"
+
+	cloudflareoperatoriov1 "github.com/containeroo/cloudflare-operator/api/v1"
+	intpredicates "github.com/containeroo/cloudflare-operator/internal/predicates"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// TLSRouteReconciler reconciles a Gateway API TLSRoute object
+type TLSRouteReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+
+	RetryInterval            time.Duration
+	DefaultReconcileInterval time.Duration
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *TLSRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&gatewayv1.TLSRoute{}, builder.WithPredicates(intpredicates.DNSFromTLSRoutePredicate{})).
+		Owns(&cloudflareoperatoriov1.DNSRecord{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Complete(r)
+}
+
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=tlsroutes,verbs=get;list;watch
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=tlsroutes/finalizers,verbs=update
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+func (r *TLSRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	tlsRoute := &gatewayv1.TLSRoute{}
+	if err := r.Get(ctx, req.NamespacedName, tlsRoute); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	return r.reconcileTLSRoute(ctx, tlsRoute)
+}
+
+// reconcileTLSRoute reconciles the TLSRoute
+func (r *TLSRouteReconciler) reconcileTLSRoute(ctx context.Context, tlsRoute *gatewayv1.TLSRoute) (ctrl.Result, error) {
+	hostReconciler := DNSHostReconciler{
+		Client:                   r.Client,
+		Scheme:                   r.Scheme,
+		RetryInterval:            r.RetryInterval,
+		DefaultReconcileInterval: r.DefaultReconcileInterval,
+	}
+	return hostReconciler.Reconcile(ctx, tlsRoute, tlsRoute.GetAnnotations(), r.getRouteHosts(tlsRoute))
+}
+
+// getRouteHosts returns a map of hosts from the TLSRoute hostnames
+func (r *TLSRouteReconciler) getRouteHosts(tlsRoute *gatewayv1.TLSRoute) map[string]struct{} {
+	hosts := make(map[string]struct{})
+	for _, hostname := range tlsRoute.Spec.Hostnames {
+		if hostname != "" {
+			hosts[string(hostname)] = struct{}{}
+		}
+	}
+	return hosts
+}

--- a/internal/controller/tlsroute_controller_test.go
+++ b/internal/controller/tlsroute_controller_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2025 containeroo
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	cloudflareoperatoriov1 "github.com/containeroo/cloudflare-operator/api/v1"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestTLSRouteReconciler_reconcileTLSRoute(t *testing.T) {
+	tlsRoute := &gatewayv1.TLSRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tlsroute",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"cloudflare-operator.io/content": "1.1.1.1",
+			},
+		},
+		Spec: gatewayv1.TLSRouteSpec{
+			Hostnames: []gatewayv1.Hostname{
+				"tls.containeroo-test.org",
+			},
+		},
+	}
+
+	r := &TLSRouteReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(NewTestScheme()).
+			WithObjects(tlsRoute).
+			WithIndex(&cloudflareoperatoriov1.DNSRecord{}, cloudflareoperatoriov1.OwnerRefUIDIndexKey, func(obj client.Object) []string {
+				dnsRecord, ok := obj.(*cloudflareoperatoriov1.DNSRecord)
+				if !ok {
+					return nil
+				}
+				if len(dnsRecord.OwnerReferences) == 0 {
+					return nil
+				}
+				return []string{string(dnsRecord.OwnerReferences[0].UID)}
+			}).
+			Build(),
+		Scheme:                   NewTestScheme(),
+		DefaultReconcileInterval: time.Minute,
+	}
+
+	t.Run("reconcile tlsroute", func(t *testing.T) {
+		g := NewWithT(t)
+		tlsRoute.Spec.Hostnames = []gatewayv1.Hostname{"tls.containeroo-test.org"}
+
+		_, err := r.reconcileTLSRoute(context.TODO(), tlsRoute)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		dnsRecord := &cloudflareoperatoriov1.DNSRecord{}
+		err = r.Get(context.TODO(), client.ObjectKey{Namespace: "default", Name: "tls-containeroo-test-org"}, dnsRecord)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		g.Expect(dnsRecord.Spec).To(HaveField("Name", Equal("tls.containeroo-test.org")))
+		g.Expect(dnsRecord.Spec).To(HaveField("Content", Equal("1.1.1.1")))
+	})
+
+	t.Run("change dnsrecord spec when annotations change", func(t *testing.T) {
+		g := NewWithT(t)
+		tlsRoute.Annotations = map[string]string{
+			"cloudflare-operator.io/content": "2.2.2.2",
+		}
+
+		_, err := r.reconcileTLSRoute(context.TODO(), tlsRoute)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		dnsRecord := &cloudflareoperatoriov1.DNSRecord{}
+		err = r.Get(context.TODO(), client.ObjectKey{Namespace: "default", Name: "tls-containeroo-test-org"}, dnsRecord)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		g.Expect(dnsRecord.Spec).To(HaveField("Name", Equal("tls.containeroo-test.org")))
+		g.Expect(dnsRecord.Spec).To(HaveField("Content", Equal("2.2.2.2")))
+	})
+
+	t.Run("reconcile tlsroute wildcard", func(t *testing.T) {
+		g := NewWithT(t)
+		tlsRoute.Spec.Hostnames = []gatewayv1.Hostname{"*.containeroo-test.org"}
+
+		_, err := r.reconcileTLSRoute(context.TODO(), tlsRoute)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		dnsRecord := &cloudflareoperatoriov1.DNSRecord{}
+		err = r.Get(context.TODO(), client.ObjectKey{Namespace: "default", Name: "wildcard-containeroo-test-org"}, dnsRecord)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		g.Expect(dnsRecord.Spec).To(HaveField("Name", Equal("*.containeroo-test.org")))
+		g.Expect(dnsRecord.Spec).To(HaveField("Content", Equal("2.2.2.2")))
+	})
+
+	t.Run("remove dnsrecord when annotations are absent", func(t *testing.T) {
+		g := NewWithT(t)
+		tlsRoute.Annotations = map[string]string{}
+
+		_, err := r.reconcileTLSRoute(context.TODO(), tlsRoute)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		dnsRecord := &cloudflareoperatoriov1.DNSRecord{}
+		err = r.Get(context.TODO(), client.ObjectKey{Namespace: "default", Name: "wildcard-containeroo-test-org"}, dnsRecord)
+		g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	})
+}

--- a/internal/predicates/predicates.go
+++ b/internal/predicates/predicates.go
@@ -97,25 +97,59 @@ func (DNSFromHTTPRoutePredicate) Update(e event.UpdateEvent) bool {
 	newObj := e.ObjectNew.(*gatewayv1.HTTPRoute)
 
 	annotationsChanged := !reflect.DeepEqual(oldAnnotations, newAnnotations)
-	oldHosts := make([]string, 0, len(oldObj.Spec.Hostnames))
-	for _, hostname := range oldObj.Spec.Hostnames {
-		oldHosts = append(oldHosts, string(hostname))
-	}
-	newHosts := make([]string, 0, len(newObj.Spec.Hostnames))
-	for _, hostname := range newObj.Spec.Hostnames {
-		newHosts = append(newHosts, string(hostname))
-	}
-
-	slices.Sort(oldHosts)
-	slices.Sort(newHosts)
-
-	hostsChanged := !reflect.DeepEqual(oldHosts, newHosts)
+	hostsChanged := gatewayHostnamesChanged(oldObj.Spec.Hostnames, newObj.Spec.Hostnames)
 
 	return (newObjectHasRequiredAnnotations && (annotationsChanged || hostsChanged)) || (oldObjectHadRequiredAnnotations && !newObjectHasRequiredAnnotations)
 }
 
 func (DNSFromHTTPRoutePredicate) Delete(e event.DeleteEvent) bool {
 	return false
+}
+
+// DNSFromTLSRoutePredicate detects if a TLSRoute object has the required annotations,
+// has changed annotations or has changed hostnames.
+type DNSFromTLSRoutePredicate struct {
+	predicate.Funcs
+}
+
+func (DNSFromTLSRoutePredicate) Create(e event.CreateEvent) bool {
+	return hasRequiredDNSAnnotations(e.Object.GetAnnotations())
+}
+
+func (DNSFromTLSRoutePredicate) Update(e event.UpdateEvent) bool {
+	oldAnnotations := e.ObjectOld.GetAnnotations()
+	newAnnotations := e.ObjectNew.GetAnnotations()
+
+	oldObjectHadRequiredAnnotations := hasRequiredDNSAnnotations(oldAnnotations)
+	newObjectHasRequiredAnnotations := hasRequiredDNSAnnotations(newAnnotations)
+
+	oldObj := e.ObjectOld.(*gatewayv1.TLSRoute)
+	newObj := e.ObjectNew.(*gatewayv1.TLSRoute)
+
+	annotationsChanged := !reflect.DeepEqual(oldAnnotations, newAnnotations)
+	hostsChanged := gatewayHostnamesChanged(oldObj.Spec.Hostnames, newObj.Spec.Hostnames)
+
+	return (newObjectHasRequiredAnnotations && (annotationsChanged || hostsChanged)) || (oldObjectHadRequiredAnnotations && !newObjectHasRequiredAnnotations)
+}
+
+func (DNSFromTLSRoutePredicate) Delete(e event.DeleteEvent) bool {
+	return false
+}
+
+func gatewayHostnamesChanged(oldHostnames, newHostnames []gatewayv1.Hostname) bool {
+	oldHosts := make([]string, 0, len(oldHostnames))
+	for _, hostname := range oldHostnames {
+		oldHosts = append(oldHosts, string(hostname))
+	}
+	newHosts := make([]string, 0, len(newHostnames))
+	for _, hostname := range newHostnames {
+		newHosts = append(newHosts, string(hostname))
+	}
+
+	slices.Sort(oldHosts)
+	slices.Sort(newHosts)
+
+	return !reflect.DeepEqual(oldHosts, newHosts)
 }
 
 // IPAddressChangedPredicate detects if an Ingress object has a change in the IP address.

--- a/internal/predicates/predicates_test.go
+++ b/internal/predicates/predicates_test.go
@@ -189,6 +189,57 @@ func TestPredicate(t *testing.T) {
 		g.Expect(result).To(BeTrue())
 	})
 
+	t.Run("create tlsroute annotation predicate with annotation", func(t *testing.T) {
+		g := NewWithT(t)
+
+		tlsRoute := &gatewayv1.TLSRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "tlsroute",
+				Annotations: map[string]string{
+					"cloudflare-operator.io/content": "test",
+				},
+			},
+		}
+
+		predicate := DNSFromTLSRoutePredicate{}
+		result := predicate.Create(event.CreateEvent{Object: tlsRoute})
+
+		g.Expect(result).To(BeTrue())
+	})
+
+	t.Run("update tlsroute hostname predicate", func(t *testing.T) {
+		g := NewWithT(t)
+
+		oldTLSRoute := &gatewayv1.TLSRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "tlsroute",
+				Annotations: map[string]string{
+					"cloudflare-operator.io/content": "test",
+				},
+			},
+			Spec: gatewayv1.TLSRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"test.containeroo-test.org"},
+			},
+		}
+
+		newTLSRoute := &gatewayv1.TLSRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "tlsroute",
+				Annotations: map[string]string{
+					"cloudflare-operator.io/content": "test",
+				},
+			},
+			Spec: gatewayv1.TLSRouteSpec{
+				Hostnames: []gatewayv1.Hostname{"test-new.containeroo-test.org"},
+			},
+		}
+
+		predicate := DNSFromTLSRoutePredicate{}
+		result := predicate.Update(event.UpdateEvent{ObjectOld: oldTLSRoute, ObjectNew: newTLSRoute})
+
+		g.Expect(result).To(BeTrue())
+	})
+
 	t.Run("update ip dnsrecord predicate", func(t *testing.T) {
 		g := NewWithT(t)
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -51,6 +51,10 @@ var _ = Describe("controller", Ordered, func() {
 		cmd = exec.Command("kubectl", "delete", "httproutes", "--all", "--all-namespaces")
 		_, _ = utils.Run(cmd)
 
+		By("removing all tlsroutes")
+		cmd = exec.Command("kubectl", "delete", "tlsroutes", "--all", "--all-namespaces")
+		_, _ = utils.Run(cmd)
+
 		By("removing all dnsrecords")
 		cmd = exec.Command("kubectl", "delete", "dnsrecords", "--all", "--all-namespaces")
 		_, _ = utils.Run(cmd)
@@ -104,7 +108,7 @@ var _ = Describe("controller", Ordered, func() {
 				"kubectl",
 				"apply",
 				"-f",
-				"https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.0/standard-install.yaml",
+				"https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml",
 			)
 			_, err = utils.Run(cmd)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
@@ -290,5 +294,36 @@ var _ = Describe("controller", Ordered, func() {
 
 		Eventually(utils.VerifyDNSRecordAbsent, time.Minute, time.Second).
 			WithArguments("sample-containeroo-test-org").Should(Succeed())
+	})
+
+	It("should create dnsrecord from a tlsroute", func() {
+		cmd := exec.Command("kubectl", "apply", "-f", "config/samples/gateway_v1_tlsroute.yaml")
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(utils.VerifyObjectReady, time.Minute, time.Second).
+			WithArguments("dnsrecord", "tls-containeroo-test-org").Should(Succeed())
+	})
+
+	It("should update dnsrecord when tlsroute annotations change", func() {
+		cmd := exec.Command(
+			"kubectl", "-n", namespace, "patch", "tlsroute", "sample-tlsroute",
+			"--type=merge", "-p", `{"metadata":{"annotations":{"cloudflare-operator.io/content":"166.166.166.166"}}}`)
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(utils.VerifyDNSRecordContent, time.Minute, time.Second).
+			WithArguments("tls-containeroo-test-org", "166.166.166.166").Should(Succeed())
+	})
+
+	It("should delete dnsrecord when tlsroute annotations are absent", func() {
+		cmd := exec.Command(
+			"kubectl", "-n", namespace, "patch", "tlsroute", "sample-tlsroute",
+			"--type=json", "-p", `[{"op": "remove", "path": "/metadata/annotations"}]`)
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(utils.VerifyDNSRecordAbsent, time.Minute, time.Second).
+			WithArguments("tls-containeroo-test-org").Should(Succeed())
 	})
 })


### PR DESCRIPTION
## Summary
- Add a TLSRoute reconciler that creates, updates, and deletes DNSRecords from Gateway API TLSRoute hostnames.
- Reuse the existing Gateway API feature flag and start route controllers based on available Gateway API CRDs.
- Add RBAC, sample manifests, unit tests, and e2e coverage for TLSRoute.

## Validation
- `go test $(go list ./... | grep -v /e2e)`

Closes #522